### PR TITLE
Read stream properties before sending stream format

### DIFF
--- a/c_src/membrane_camera_capture_plugin/camera_capture.c
+++ b/c_src/membrane_camera_capture_plugin/camera_capture.c
@@ -1,6 +1,7 @@
 #include "./camera_capture.h"
 
 #include <libavdevice/avdevice.h>
+#include <libavutil/pixdesc.h>
 #include <string.h>
 
 #if defined(WIN32) || defined(_WIN32) || defined(__WIN32__) || defined(__NT__)
@@ -73,6 +74,11 @@ UNIFEX_TERM read_packet(UnifexEnv *env, State *state) {
 end:
   av_packet_unref(&packet);
   return ret;
+}
+
+UNIFEX_TERM stream_props(UnifexEnv *env, State *state) {
+  AVCodecParameters *codec_params = state->input_ctx->streams[0]->codecpar;
+  return stream_props_result_ok(env, codec_params->width, codec_params->height, av_get_pix_fmt_name(codec_params->format));
 }
 
 void handle_destroy_state(UnifexEnv *_env, State *state) {

--- a/c_src/membrane_camera_capture_plugin/camera_capture.spec.exs
+++ b/c_src/membrane_camera_capture_plugin/camera_capture.spec.exs
@@ -6,5 +6,6 @@ spec do_open(url :: string, framerate :: string) ::
        {:ok :: label, state} | {:error :: label, reason :: atom}
 
 spec read_packet(state) :: {:ok :: label, payload} | {:error :: label, reason :: atom}
+spec stream_props(state) :: {:ok :: label, width :: int, height :: int, pixel_format :: string}
 
 dirty :cpu, read_packet: 1

--- a/lib/membrane_camera_capture_plugin/camera.ex
+++ b/lib/membrane_camera_capture_plugin/camera.ex
@@ -33,10 +33,12 @@ defmodule Membrane.CameraCapture do
 
   @impl true
   def handle_playing(ctx, state) do
+    {:ok, width, height, pixel_format} = Native.stream_props(state.native)
+
     stream_format = %Membrane.RawVideo{
-      width: 1280,
-      height: 720,
-      pixel_format: :NV12,
+      width: width,
+      height: height,
+      pixel_format: pixel_format_to_atom(pixel_format),
       aligned: true,
       framerate: {30, 1}
     }
@@ -82,4 +84,14 @@ defmodule Membrane.CameraCapture do
   def handle_info({:frame_provider, _buffer}, _ctx, state) do
     {[], state}
   end
+
+  defp pixel_format_to_atom("yuv420"), do: :I420
+  defp pixel_format_to_atom("yuv422p"), do: :I422
+  defp pixel_format_to_atom("yuv444p"), do: :I444
+  defp pixel_format_to_atom("rgb24"), do: :RGB
+  defp pixel_format_to_atom("rgba"), do: :RGBA
+  defp pixel_format_to_atom("yuyv422"), do: :YUYV
+  defp pixel_format_to_atom("nv12"), do: :NV12
+  defp pixel_format_to_atom("nv21"), do: :NV21
+  defp pixel_format_to_atom(pixel_format), do: raise("unsupported pixel format #{pixel_format}")
 end

--- a/lib/membrane_camera_capture_plugin/camera.ex
+++ b/lib/membrane_camera_capture_plugin/camera.ex
@@ -85,12 +85,12 @@ defmodule Membrane.CameraCapture do
     {[], state}
   end
 
-  defp pixel_format_to_atom("yuv420"), do: :I420
+  defp pixel_format_to_atom("yuv420p"), do: :I420
   defp pixel_format_to_atom("yuv422p"), do: :I422
   defp pixel_format_to_atom("yuv444p"), do: :I444
   defp pixel_format_to_atom("rgb24"), do: :RGB
   defp pixel_format_to_atom("rgba"), do: :RGBA
-  defp pixel_format_to_atom("yuyv422"), do: :YUYV
+  defp pixel_format_to_atom("yuyv422"), do: :YUY2
   defp pixel_format_to_atom("nv12"), do: :NV12
   defp pixel_format_to_atom("nv21"), do: :NV21
   defp pixel_format_to_atom(pixel_format), do: raise("unsupported pixel format #{pixel_format}")


### PR DESCRIPTION
We fix the resolution to `1280 x 720`, if the device has a different resolution it'll not be processed correctly. Also setting the pixel format to `nv12` is ignored if the device doesn't support this format.

In this PR, we read the stream properties from `AVFormatContext` and set the correct `width`, `height` and `pixel format`. Also added the format `YUYV` as it's used by many integrated/web cameras.